### PR TITLE
fix spacing in service.yaml

### DIFF
--- a/charts/tinyauth/templates/service.yaml
+++ b/charts/tinyauth/templates/service.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "tinyauth.fullname" . }}
-  labels: {{- include "tinyauth.labels" . | nindent 4 }}
+  labels:
+    {{- include "tinyauth.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -10,4 +11,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-  selector: {{- include "tinyauth.selectorLabels" . | nindent 4 }}
+  selector:
+    {{- include "tinyauth.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Before this change, running:
```
helm template charts/tinyauth
```
would result in the error:
```
Error: YAML parse error on tinyauth/templates/service.yaml:
error converting YAML to JSON:
yaml: line 4: did not find expected node content
```
Afterwards, it successfully outputs kubernetes resources.