### PR TITLE
add deploymentStrategy.type

### DIFF
--- a/charts/tinyauth/README.md
+++ b/charts/tinyauth/README.md
@@ -14,6 +14,7 @@ The simplest way to protect your apps with a login screen.
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| deploymentStrategy.type | string | `"RollingUpdate"` |  |
 | env | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | httpRoute.annotations | object | `{}` |  |

--- a/charts/tinyauth/ci/all-features-values.yaml
+++ b/charts/tinyauth/ci/all-features-values.yaml
@@ -1,4 +1,6 @@
 replicaCount: 1
+deploymentStrategy:
+  type: Recreate
 
 env:
   - name: CUSTOM_VAR

--- a/charts/tinyauth/templates/deployment.yaml
+++ b/charts/tinyauth/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "tinyauth.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/charts/tinyauth/values.schema.json
+++ b/charts/tinyauth/values.schema.json
@@ -30,6 +30,15 @@
                 }
             }
         },
+        "deploymentStrategy": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "default": "RollingUpdate",
+                    "type": "string"
+                }
+            }
+        },
         "env": {
             "default": [],
             "type": "array"

--- a/charts/tinyauth/values.yaml
+++ b/charts/tinyauth/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1 # @schema default: 1
+deploymentStrategy:
+  type: RollingUpdate # @schema default: "RollingUpdate"
 
 image:
   repository: ghcr.io/steveiliop56/tinyauth # @schema default: "ghcr.io/steveiliop56/tinyauth"


### PR DESCRIPTION
The default `type: RollingUpdate` preserves existing behavior.
Setting `type: Recreate` enables use of `ReadWriteOnce` volumes.